### PR TITLE
Fix for the empty result

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ async function run() {
                     passphrase,
                 });
             }
-            var { data: result } = await openpgp.sign({
+            const result = await openpgp.sign({
                 message: await openpgp.createCleartextMessage({ text }),
                 signingKeys: [privateKey],
             });
@@ -91,7 +91,7 @@ async function run() {
             const publicKey = await openpgp.readKey({
                 armoredKey: key,
             });
-            var { data: result } = await openpgp.encrypt({
+            const result = await openpgp.encrypt({
                 message: message,
                 encryptionKeys: publicKey,
                 signingKeys: !!privateKey ? privateKey : null,


### PR DESCRIPTION
openpgp.sign and openpgp.encrypt return String, not an Object anymore.
Fixing "Property 'data' does not exist on type 'String'" error